### PR TITLE
Enables OPTIONS HTTP method for preflight requests in the FE

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -537,3 +537,11 @@ def batch(request, response, storage, *args, **kwargs):
             response.write("\r\n\r\n")
 
     response.write("--{}--".format(boundary))
+
+
+def options(request, response, storage, *args, **kwargs):
+    response.write("HTTP/1.1 200 OK\r\n")
+    response.write("Content-Type: text/html; charset=UTF-8\r\n")
+    response.write("allow: OPTIONS,GET,POST,PUT,DELETE,PATCH\r\n")
+    response.write("Access-Control-Allow-Origin: *\r\n")
+    response.write("Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS\r\n")

--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -544,4 +544,6 @@ def options(request, response, storage, *args, **kwargs):
     response.write("Content-Type: text/html; charset=UTF-8\r\n")
     response.write("allow: OPTIONS,GET,POST,PUT,DELETE,PATCH\r\n")
     response.write("Access-Control-Allow-Origin: *\r\n")
-    response.write("Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS\r\n")
+    response.write(
+        "Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS\r\n"
+    )

--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -543,7 +543,7 @@ def options(request, response, storage, *args, **kwargs):
     response.write("HTTP/1.1 200 OK\r\n")
     response.write("Content-Type: text/html; charset=UTF-8\r\n")
     response.write("allow: OPTIONS,GET,POST,PUT,DELETE,PATCH\r\n")
-    response.write("Access-Control-Allow-Origin: *\r\n")
+    response.write("access-control-allow-origin: *\r\n")
     response.write(
-        "Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS\r\n"
+        "access-control-allow-methods: GET,POST,PUT,PATCH,DELETE,OPTIONS\r\n"
     )

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -40,7 +40,7 @@ def _health_check(req, res, storage):
 
 
 HANDLERS = (
-    (r"^{}/b$".format(settings.API_ENDPOINT), {GET: buckets.ls, POST: buckets.insert}),
+    (r"^{}/b$".format(settings.API_ENDPOINT), {GET: buckets.ls, POST: buckets.insert, OPTIONS: objects.options}),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)$".format(settings.API_ENDPOINT),
         {GET: buckets.get, DELETE: buckets.delete, OPTIONS: objects.options},

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -301,7 +301,9 @@ class Response(object):
         return self._headers[key]
 
     def close(self):
+        # Set permissive CORS
         self["Access-Control-Allow-Origin"] = "*"
+
         self._handler.send_response(self.status.value, self.status.phrase)
         for k, v in self._headers.items():
             self._handler.send_header(k, v)
@@ -333,6 +335,7 @@ class Router(object):
         for regex, handlers in HANDLERS:
             pattern = re.compile(regex)
             match = pattern.fullmatch(request.path)
+            logger.info(pattern, match)
             if match:
                 request.set_match(match)
                 handler = handlers.get(method)

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -352,8 +352,6 @@ class Router(object):
                 "Method not implemented: {} - {}".format(request.method, request.path)
             )
             response.status = HTTPStatus.NOT_IMPLEMENTED
-
-        response._headers[]
         
         response.close()
 

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -332,10 +332,12 @@ class Router(object):
         request = Request(self._request_handler, method)
         response = Response(self._request_handler)
 
+        logger.info(f"{method}, {request.path}")
+
         for regex, handlers in HANDLERS:
             pattern = re.compile(regex)
             match = pattern.fullmatch(request.path)
-            logger.info(f"{method}, {request.path}")
+            
             if match:
                 request.set_match(match)
                 handler = handlers.get(method)

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -301,11 +301,12 @@ class Response(object):
         return self._headers[key]
 
     def close(self):
+        self["Access-Control-Allow-Origin"] = "*"
         self._handler.send_response(self.status.value, self.status.phrase)
         for k, v in self._headers.items():
             self._handler.send_header(k, v)
 
-        self._handler.send_header("Access-Control-Allow-Origin", "*")
+        # self._handler.send_header("Access-Control-Allow-Origin", "*")
 
         content = self._content
 

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -305,6 +305,8 @@ class Response(object):
         for k, v in self._headers.items():
             self._handler.send_header(k, v)
 
+        self._handler.send_header("Access-Control-Allow-Origin", "*")
+
         content = self._content
 
         if isinstance(self._content, str):
@@ -351,6 +353,8 @@ class Router(object):
             )
             response.status = HTTPStatus.NOT_IMPLEMENTED
 
+        response._headers[]
+        
         response.close()
 
 

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -308,8 +308,6 @@ class Response(object):
         for k, v in self._headers.items():
             self._handler.send_header(k, v)
 
-        # self._handler.send_header("Access-Control-Allow-Origin", "*")
-
         content = self._content
 
         if isinstance(self._content, str):
@@ -339,6 +337,7 @@ class Router(object):
             match = pattern.fullmatch(request.path)
             
             if match:
+                logger.info(f"Found match for regex!")
                 request.set_match(match)
                 handler = handlers.get(method)
                 try:

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -335,7 +335,7 @@ class Router(object):
         for regex, handlers in HANDLERS:
             pattern = re.compile(regex)
             match = pattern.fullmatch(request.path)
-            logger.info(method, pattern)
+            logger.info(f"{method}, {request.path}")
             if match:
                 request.set_match(match)
                 handler = handlers.get(method)

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -36,7 +36,6 @@ def _wipe_data(req, res, storage):
 
 
 def _health_check(req, res, storage):
-    logger.info("What the hell is going on?")
     res.write("OK")
 
 

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -335,7 +335,7 @@ class Router(object):
         for regex, handlers in HANDLERS:
             pattern = re.compile(regex)
             match = pattern.fullmatch(request.path)
-            logger.info(pattern, match)
+            logger.info(method, pattern)
             if match:
                 request.set_match(match)
                 handler = handlers.get(method)

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -36,6 +36,7 @@ def _wipe_data(req, res, storage):
 
 
 def _health_check(req, res, storage):
+    logger.info("What the hell is going on?")
     res.write("OK")
 
 
@@ -301,9 +302,6 @@ class Response(object):
         return self._headers[key]
 
     def close(self):
-        # Set permissive CORS
-        self["Access-Control-Allow-Origin"] = "*"
-
         self._handler.send_response(self.status.value, self.status.phrase)
         for k, v in self._headers.items():
             self._handler.send_header(k, v)
@@ -330,14 +328,13 @@ class Router(object):
         request = Request(self._request_handler, method)
         response = Response(self._request_handler)
 
-        logger.info(f"{method}, {request.path}")
+        response["Access-Control-Allow-Origin"] = "*"
 
         for regex, handlers in HANDLERS:
             pattern = re.compile(regex)
             match = pattern.fullmatch(request.path)
             
             if match:
-                logger.info(f"Found match for regex!")
                 request.set_match(match)
                 handler = handlers.get(method)
                 try:

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -21,6 +21,7 @@ POST = "POST"
 PUT = "PUT"
 DELETE = "DELETE"
 PATCH = "PATCH"
+OPTIONS = "OPTIONS"
 
 
 def _wipe_data(req, res, storage):
@@ -42,53 +43,53 @@ HANDLERS = (
     (r"^{}/b$".format(settings.API_ENDPOINT), {GET: buckets.ls, POST: buckets.insert}),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)$".format(settings.API_ENDPOINT),
-        {GET: buckets.get, DELETE: buckets.delete},
+        {GET: buckets.get, DELETE: buckets.delete, OPTIONS: objects.options},
     ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o$".format(settings.API_ENDPOINT),
-        {GET: objects.ls},
+        {GET: objects.ls, OPTIONS: objects.options},
     ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)/copyTo/b/".format(
             settings.API_ENDPOINT
         )
         + r"(?P<dest_bucket_name>[-.\w]+)/o/(?P<dest_object_id>.*[^/]+)$",
-        {POST: objects.copy},
+        {POST: objects.copy, OPTIONS: objects.options},
     ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)/compose$".format(
             settings.API_ENDPOINT
         ),
-        {POST: objects.compose},
+        {POST: objects.compose, OPTIONS: objects.options},
     ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)$".format(
             settings.API_ENDPOINT
         ),
-        {GET: objects.get, DELETE: objects.delete, PATCH: objects.patch},
+        {GET: objects.get, DELETE: objects.delete, PATCH: objects.patch, OPTIONS: objects.options},
     ),
     # Non-default API endpoints
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o$".format(settings.UPLOAD_API_ENDPOINT),
-        {POST: objects.insert, PUT: objects.upload_partial},
+        {POST: objects.insert, PUT: objects.upload_partial, OPTIONS: objects.options},
     ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)$".format(
             settings.DOWNLOAD_API_ENDPOINT
         ),
-        {GET: objects.download},
+        {GET: objects.download, OPTIONS: objects.options},
     ),
     (
         r"^{}$".format(settings.BATCH_API_ENDPOINT),
-        {POST: objects.batch},
+        {POST: objects.batch, OPTIONS: objects.options},
     ),
     # Internal API, not supported by the real GCS
-    (r"^/$", {GET: _health_check}),  # Health check endpoint
-    (r"^/wipe$", {GET: _wipe_data}),  # Wipe all data
+    (r"^/$", {GET: _health_check, OPTIONS: objects.options}),  # Health check endpoint
+    (r"^/wipe$", {GET: _wipe_data, OPTIONS: objects.options}),  # Wipe all data
     # Public file serving, same as object.download and signed URLs
     (
         r"^/(?P<bucket_name>[-.\w]+)/(?P<object_id>.*[^/]+)$",
-        {GET: objects.download, PUT: objects.xml_upload},
+        {GET: objects.download, PUT: objects.xml_upload, OPTIONS: objects.options},
     ),
 )
 
@@ -369,6 +370,10 @@ class RequestHandler(server.BaseHTTPRequestHandler):
     def do_PATCH(self):
         router = Router(self)
         router.handle(PATCH)
+
+    def do_OPTIONS(self):
+        router = Router(self)
+        router.handle(OPTIONS)
 
     def log_message(self, format, *args):
         logger.info(format % args)

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -40,7 +40,10 @@ def _health_check(req, res, storage):
 
 
 HANDLERS = (
-    (r"^{}/b$".format(settings.API_ENDPOINT), {GET: buckets.ls, POST: buckets.insert, OPTIONS: objects.options}),
+    (
+        r"^{}/b$".format(settings.API_ENDPOINT),
+        {GET: buckets.ls, POST: buckets.insert, OPTIONS: objects.options},
+    ),
     (
         r"^{}/b/(?P<bucket_name>[-.\w]+)$".format(settings.API_ENDPOINT),
         {GET: buckets.get, DELETE: buckets.delete, OPTIONS: objects.options},
@@ -66,7 +69,12 @@ HANDLERS = (
         r"^{}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)$".format(
             settings.API_ENDPOINT
         ),
-        {GET: objects.get, DELETE: objects.delete, PATCH: objects.patch, OPTIONS: objects.options},
+        {
+            GET: objects.get,
+            DELETE: objects.delete,
+            PATCH: objects.patch,
+            OPTIONS: objects.options,
+        },
     ),
     # Non-default API endpoints
     (

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,3 +76,9 @@ class MainHttpEndpointsTest(ServerBaseCase):
         response = requests.get(url)
         self.assertEqual(response.status_code, 501)
         self.assertEqual(response.content, "".encode("utf-8"))
+
+    def test_options(self):
+        url = self._url("/")
+        response = requests.options(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("GET,POST,PUT,PATCH,DELETE,OPTIONS" in response.headers['Access-Control-Allow-Methods'])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,5 +83,5 @@ class MainHttpEndpointsTest(ServerBaseCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(
             "GET,POST,PUT,PATCH,DELETE,OPTIONS"
-            in response.headers["Access-Control-Allow-Methods"]
+            in response.headers["access-control-allow-methods"]
         )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,4 +81,7 @@ class MainHttpEndpointsTest(ServerBaseCase):
         url = self._url("/")
         response = requests.options(url)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("GET,POST,PUT,PATCH,DELETE,OPTIONS" in response.headers['Access-Control-Allow-Methods'])
+        self.assertTrue(
+            "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+            in response.headers["Access-Control-Allow-Methods"]
+        )


### PR DESCRIPTION
This PR should fix the error we have when trying to stream (PUT) data into our signed URLS, using the emulator locally. Currently, it doesn't support OPTIONS, nor it returns a permissive `access-control-allow-origin` header. 